### PR TITLE
Issue #39 - imgui_new_frame_system should always start a new ImGui frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following examples are provided:
 
 ## Changelog
 
-* `0.5.0` - Add support for drawing Bevy textures in ImGui windows
+* `0.5.0` - Add support for drawing Bevy textures in ImGui windows. Fix assert on exit introduced in Bevy 0.14.1
 * `0.4.0` - Updated dependencies for Bevy `0.14.0`. Improved handling of display scale changes.
 * `0.3.0` - Updated dependencies for Bevy `0.13.0` with bundled `imgui-wgpu-rs`.
 * `0.2.1` - Fix Issue #20 - unchecked window lookup which could cause panic during exit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -641,20 +641,18 @@ fn imgui_new_frame_system(
         UNKNOWN_KEYCODE, // ReservedForModSuper = sys::ImGuiKey_ReservedForModSuper
     ];
 
-    let Ok((_, primary)) = primary_window.get_single() else {
-        return;
-    };
-
     let ui_ptr: *mut imgui::Ui;
     {
         let mut ctx = context.ctx.lock().unwrap();
         let io = ctx.io_mut();
 
-        io.display_size = [primary.width(), primary.height()];
-        io.display_framebuffer_scale = [primary.scale_factor(), primary.scale_factor()];
+        if let Ok((_, primary)) = primary_window.get_single() {
+            io.display_size = [primary.width(), primary.height()];
+            io.display_framebuffer_scale = [primary.scale_factor(), primary.scale_factor()];
 
-        if let Some(pos) = primary.cursor_position() {
-            io.mouse_pos = [pos.x, pos.y];
+            if let Some(pos) = primary.cursor_position() {
+                io.mouse_pos = [pos.x, pos.y];
+            }
         }
 
         io.mouse_down[0] = mouse.pressed(bevy::input::mouse::MouseButton::Left);


### PR DESCRIPTION
Prior to this change, we would exit early if the primary window was not available. In Bevy 0.14.1, the system update order in the Update phase was updated such that a new frame is now fully evaluated having destroyed the primary window. Because we were exiting early, we weren't starting a new ImGui frame in this case, and this lead to other systems triggering an ImGui assert if they attempt to interact with the ImGui context. To guard against this, we now always return from imgui_new_frame_system having began a new ImGui frame.