### PR TITLE
Threading cleanup, fixes & safety improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ features = ["bevy_core_pipeline", "bevy_render"]
 [dev-dependencies.bevy]
 version = "0.14"
 default-features = false
-features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", "bevy_winit", "png"]
+features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", "bevy_winit", "png", "multi_threaded"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,7 +507,7 @@ impl Plugin for ImguiPlugin {
         app.insert_non_send_resource(context);
 
         app.add_systems(PreUpdate, imgui_new_frame_system);
-        app.add_systems(PostUpdate, imgui_end_frame_system);
+        app.add_systems(Last, imgui_end_frame_system);
     }
 }
 


### PR DESCRIPTION
Fixes #41 

This fixes the threading logic of the library. Previously the library basically relied on an unsound usage of `unsafe impl Send` for everything to work, this is now no longer the case. There is still an `unsafe impl Send` to work around https://github.com/imgui-rs/imgui-rs/issues/815, but this is localized to the `OwnedDrawData` only.

See commits for remaining details.