### PR TITLE
Preparations for Release 0.5.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,8 +26,10 @@ If applicable, add screenshots to help explain your problem.
 **Platform (please complete the following information):**
  - Device: [e.g. PC, Mac, etc...]
  - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+ - Version: [e.g. 22]
+ - Rust Version:
+ - Bevy Version:
+ - WGPU Renderer Backend: [e.g. DX12, Vulcan, etc]
 
 **Additional context**
 Add any other context about the problem here.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mod_imgui"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["game-engines", "graphics", "gui", "rendering"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The following examples are provided:
 
 ## Changelog
 
+* `0.5.1` - Various threading and safety fixes. Fix crash when plugin used with Bevy `multi_threaded` feature
 * `0.5.0` - Add support for drawing Bevy textures in ImGui windows. Fix assert on exit introduced in Bevy 0.14.1
 * `0.4.0` - Updated dependencies for Bevy `0.14.0`. Improved handling of display scale changes.
 * `0.3.0` - Updated dependencies for Bevy `0.13.0` with bundled `imgui-wgpu-rs`.
@@ -52,6 +53,7 @@ The following examples are provided:
 
 * James Bird (@jbrd)
 * @nhlest
+* @PJB3005
 
 ## Acknowledgements
 

--- a/examples/hello-world-postupdate.rs
+++ b/examples/hello-world-postupdate.rs
@@ -1,0 +1,83 @@
+use bevy::prelude::*;
+use bevy_mod_imgui::prelude::*;
+
+#[derive(Resource)]
+struct ImguiState {
+    demo_window_open: bool,
+}
+
+fn main() {
+    let mut app = App::new();
+    app.insert_resource(ClearColor(Color::srgba(0.2, 0.2, 0.2, 1.0)))
+        .insert_resource(ImguiState {
+            demo_window_open: true,
+        })
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_plugins(bevy_mod_imgui::ImguiPlugin {
+            ini_filename: Some("hello-world.ini".into()),
+            font_oversample_h: 2,
+            font_oversample_v: 2,
+            ..default()
+        })
+        .add_systems(PostUpdate, imgui_example_ui);
+
+    app.run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // plane
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Plane3d::default().mesh().size(5.0, 5.0)),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
+        ..default()
+    });
+    // cube
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Cuboid::default().mesh()),
+        material: materials.add(Color::srgb(0.8, 0.7, 0.6)),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        ..default()
+    });
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(1.7, 1.7, 2.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+        tonemapping: bevy::core_pipeline::tonemapping::Tonemapping::None,
+        ..default()
+    });
+}
+
+fn imgui_example_ui(mut context: NonSendMut<ImguiContext>, mut state: ResMut<ImguiState>) {
+    let ui = context.ui();
+    let window = ui.window("Hello world");
+    window
+        .size([300.0, 100.0], imgui::Condition::FirstUseEver)
+        .position([0.0, 0.0], imgui::Condition::FirstUseEver)
+        .build(|| {
+            ui.text("Hello world!");
+            ui.text("This...is...bevy_mod_imgui! (from PostUpdate)");
+            ui.separator();
+            let mouse_pos = ui.io().mouse_pos;
+            ui.text(format!(
+                "Mouse Position: ({:.1},{:.1})",
+                mouse_pos[0], mouse_pos[1]
+            ));
+        });
+
+    if state.demo_window_open {
+        ui.show_demo_window(&mut state.demo_window_open);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,7 +156,7 @@ struct ImguiRenderContext {
 
 // OwnedDrawData is erroneously not marked Send, do this to make it so.
 #[derive(Default)]
-pub struct OwnedDrawDataWrap(imgui::OwnedDrawData);
+struct OwnedDrawDataWrap(imgui::OwnedDrawData);
 unsafe impl Send for OwnedDrawDataWrap {}
 unsafe impl Sync for OwnedDrawDataWrap {}
 


### PR DESCRIPTION
- Update bug report template with more applicable platform info
- Bump version number to 0.5.1
- Make visibility of OwnedDrawDataWrap non-public
- Add an example for emitting imgui UI during `PostUpdate` so we can continue to ensure this use case works