### PR TITLE
fix: Avoid panic in render call when nothing is drawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following examples are provided:
 * James Bird (@jbrd)
 * @nhlest
 * @PJB3005
+* Marius Metzger (@CrushedPixel)
 
 ## Acknowledgements
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,9 +217,12 @@ impl Node for ImGuiNode {
         let mut renderer = context.renderer.write().unwrap();
         if let Ok(mut rpass) = ImGuiNode::create_render_pass(command_encoder, world) {
             if let Some(draw_data) = context.draw.0.draw_data() {
-                renderer
-                    .render(draw_data, queue, wgpu_device, &mut rpass)
-                    .unwrap();
+                // render function panics if nothing is drawn
+                if draw_data.total_idx_count > 0 {
+                    renderer
+                        .render(draw_data, queue, wgpu_device, &mut rpass)
+                        .unwrap();
+                }
             }
         }
         Ok(())


### PR DESCRIPTION
Currently, the render function panics when the vertex list is of zero length. This is the case whenever no ImGui draw commands have been issued for a frame. 

This PR fixes the issue by simply checking if any indices are to be drawn - if so, then vertices will be non-zero as well.