### PR TITLE
feat: Support ImGui docking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ repository = "https://github.com/jbrd/bevy_mod_imgui"
 rust-version = "1.85.0"
 exclude = [".github/", ".gitignore"]
 
+[features]
+default = []
+docking = ["imgui/docking"]
+
 [dependencies]
 imgui = "0.12.0"
 wgpu = "24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,19 @@ impl ImguiContext {
         }
     }
 
+    /// Runs the given function with mutable access to the underlying `imgui::Io` object.
+    ///
+    /// Use this to configure imgui settings, for example in a Startup system.
+    pub fn with_io_mut<F, R>(&mut self, f: F) -> R
+    where
+        F: FnOnce(&mut imgui::Io) -> R,
+    {
+        unsafe {
+            let mut ctx = self.ctx.write().unwrap();
+            f(ctx.io_mut())
+        }
+    }
+
     /// Register a Bevy texture with ImGui. The provided Handle must be strong, and
     /// the texture will be kept alive until `unregister_bevy_texture` is called to
     /// release the texture.


### PR DESCRIPTION
This addresses #1.

# Overview
These are three commits:
1. Added a feature `docking` that enables `imgui/docking` feature.

2. Added `ImguiContext::with_io_mut` to allow users to mutate Imgui's I/O struct. Without being able to modify the I/O struct, there is no way for a user to enable or configure docking.

3. Add a field `config_flags` to `ImguiPlugin` that defaults to enabling docking when the `docking` feature is enabled. This makes it possible to configure Imgui via config flags without having to use `with_io_mut`. 

The third commit is technically a breaking change, as it changes `ImguiPlugin`'s struct layout, so existing code will need to be updated. Therefore, I understand if you don't want to merge this third commit - the first 2 are sufficient to properly use Imgui with docking. Just let me know if I should remove it from this branch.

# Demo
With the docking feature enabled, I added a `Startup` system that runs:
```rs
imgui.with_io_mut(|io| {
    io.config_flags |= ConfigFlags::DOCKING_ENABLE;
    io.config_docking_always_tab_bar = true;
});
```

And now my windows are dockable, without any additional Imgui API calls:
<img width="949" alt="Screenshot 2025-06-25 at 17 30 41" src="https://github.com/user-attachments/assets/9f6340fa-1653-4a95-b788-ce5eedf2d9e7" />


Please let me know your thoughts!
