### PR TITLE
Fix for invalid slice access when UI is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following examples are provided:
 * James Bird (@jbrd)
 * @nhlest
 * @PJB3005
+* Marius Metzger (@CrushedPixel)
 
 ## Acknowledgements
 

--- a/examples/empty.rs
+++ b/examples/empty.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+use bevy_mod_imgui::prelude::*;
+
+#[derive(Resource)]
+struct ImguiState;
+
+fn main() {
+    let mut app = App::new();
+    app.insert_resource(ClearColor(Color::srgba(0.2, 0.2, 0.2, 1.0)))
+        .insert_resource(ImguiState {})
+        .add_plugins(DefaultPlugins)
+        .add_plugins(bevy_mod_imgui::ImguiPlugin::default())
+        .add_systems(Startup, |mut commands: Commands| {
+            commands.spawn(Camera3d::default());
+        })
+        .add_systems(Update, imgui_example_ui);
+    app.run();
+}
+
+fn imgui_example_ui(_context: NonSendMut<ImguiContext>, _state: ResMut<ImguiState>) {
+    // Example to regression test our workaround for https://github.com/Yatekii/imgui-wgpu-rs/issues/114
+}

--- a/src/imgui_wgpu_rs_local/mod.rs
+++ b/src/imgui_wgpu_rs_local/mod.rs
@@ -679,13 +679,20 @@ impl Renderer {
             return Ok(());
         }
 
+        let vertex_buffer = render_data.vertex_buffer.as_ref().unwrap();
+        if vertex_buffer.size() == 0 {
+            return Ok(());
+        }
+
+        let index_buffer = render_data.index_buffer.as_ref().unwrap();
+        if index_buffer.size() == 0 {
+            return Ok(());
+        }
+
         rpass.set_pipeline(&self.pipeline);
         rpass.set_bind_group(0, &self.uniform_bind_group, &[]);
-        rpass.set_vertex_buffer(0, render_data.vertex_buffer.as_ref().unwrap().slice(..));
-        rpass.set_index_buffer(
-            render_data.index_buffer.as_ref().unwrap().slice(..),
-            IndexFormat::Uint16,
-        );
+        rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        rpass.set_index_buffer(index_buffer.slice(..), IndexFormat::Uint16);
 
         // Execute all the imgui render work.
         for (draw_list, bases) in draw_data


### PR DESCRIPTION
Fixing the root cause of this issue: https://github.com/jbrd/bevy_mod_imgui/pull/55
