### PR TITLE
fix: 

### DIFF
--- a/src/imgui_wgpu_rs_local/mod.rs
+++ b/src/imgui_wgpu_rs_local/mod.rs
@@ -764,8 +764,12 @@ impl Renderer {
                     let scissors = (
                         clip_rect[0].max(0.0).floor() as u32,
                         clip_rect[1].max(0.0).floor() as u32,
-                        (clip_rect[2] - clip_rect[0]).abs().ceil() as u32,
-                        (clip_rect[3] - clip_rect[1]).abs().ceil() as u32,
+                        (clip_rect[2].min(fb_size[0]) - clip_rect[0].max(0.0))
+                            .abs()
+                            .ceil() as u32,
+                        (clip_rect[3].min(fb_size[1]) - clip_rect[1].max(0.0))
+                            .abs()
+                            .ceil() as u32,
                     );
 
                     // XXX: Work-around for wgpu issue [1] by only issuing draw

--- a/src/imgui_wgpu_rs_local/mod.rs
+++ b/src/imgui_wgpu_rs_local/mod.rs
@@ -735,8 +735,6 @@ impl Renderer {
         clip_scale: [f32; 2],
         (vertex_base, index_base): (i32, u32),
     ) -> RendererResult<()> {
-        let mut start = index_base;
-
         for cmd in draw_list.commands() {
             if let Elements { count, cmd_params } = cmd {
                 let clip_rect = [
@@ -755,6 +753,7 @@ impl Renderer {
                 rpass.set_bind_group(1, Some(tex.bind_group.as_ref()), &[]);
 
                 // Set scissors on the renderpass.
+                let start = index_base + cmd_params.idx_offset as u32;
                 let end = start + count as u32;
                 if clip_rect[0] < fb_size[0]
                     && clip_rect[1] < fb_size[1]
@@ -781,13 +780,13 @@ impl Renderer {
                         rpass.set_scissor_rect(scissors.0, scissors.1, scissors.2, scissors.3);
 
                         // Draw the current batch of vertices with the renderpass.
-                        rpass.draw_indexed(start..end, vertex_base, 0..1);
+                        rpass.draw_indexed(
+                            start..end,
+                            vertex_base + cmd_params.vtx_offset as i32,
+                            0..1,
+                        );
                     }
                 }
-
-                // Increment the index regardless of whether or not this batch
-                // of vertices was drawn.
-                start = end;
             }
         }
         Ok(())


### PR DESCRIPTION
This PR introduces some changes to the wgpu renderer that I needed to make for compatibility with https://github.com/aiekick/ImGuiFileDialog.

1. incorporates an upstream fix that prevents crashes when scissor rectangle exceeds framebuffer size
2. uses the idx_offset when rendering DrawLists to correctly render modal overlays.  
See my upstream PR: https://github.com/Yatekii/imgui-wgpu-rs/pull/123,   
and this issue comment in ImGui repo: https://github.com/ocornut/imgui/issues/4863#issuecomment-1005225877

Old:
<img width="1392" alt="Screenshot 2025-06-26 at 22 55 40" src="https://github.com/user-attachments/assets/986b33e2-784c-4f19-93d6-4011f5921765" />
New:
<img width="1392" alt="Screenshot 2025-06-26 at 22 50 52" src="https://github.com/user-attachments/assets/87d2444b-343d-4126-a40b-7c7f51b3d992" />

In case you are interested in trying this, I have updated bindings to ImGuiFileDialog in my fork: https://github.com/CrushedPixel/imgui-filedialog-rs
