### PR TITLE
Issue #74 - Update to Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "bevy_mod_imgui"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A Dear ImGui integration for the Bevy game engine."
 readme = "README.md"
 repository = "https://github.com/jbrd/bevy_mod_imgui"
-rust-version = "1.88.0"
+rust-version = "1.92.0"
 exclude = [".github/", ".gitignore"]
 
 [features]
@@ -16,7 +16,7 @@ docking = ["imgui/docking"]
 
 [dependencies]
 imgui = "0.12.0"
-wgpu = "26"
+wgpu = "27"
 
 # For imgui_wgpu_rs_local
 # imgui-wgpu = "0.24.0" # temporarily bundling imgui-wgpu with this crate
@@ -25,12 +25,12 @@ log = "0.4"
 smallvec = "1"
 
 [dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0"
 default-features = false
 features = ["bevy_core_pipeline", "bevy_render", "bevy_window"]
 
 [dev-dependencies.bevy]
-version = "0.17.0"
+version = "0.18.0"
 default-features = false
 features = ["bevy_asset", "bevy_core_pipeline", "bevy_pbr", "bevy_render", "bevy_window", "bevy_winit", "png", "multi_threaded", "tonemapping_luts", "zstd_rust"]
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This crate is not related to any official Bevy organisation repository in any wa
 
 |`bevy_mod_imgui`|`bevy`  |`wgpu`  |`imgui` |`imgui-wgpu`      |
 |----------------|--------|--------|--------|------------------|
+| 0.9.*          | 0.18.* | 27.*   | 0.12.* | 0.24.0 (bundled) |
 | 0.8.*          | 0.17.* | 26.*   | 0.12.* | 0.24.0 (bundled) |
 | 0.7.*          | 0.16.* | 24.*   | 0.12.* | 0.24.0 (bundled) |
 | 0.6.*          | 0.15.* | 23.*   | 0.12.* | 0.24.0 (bundled) |
@@ -57,6 +58,7 @@ The following examples are provided:
 
 ## Changelog
 
+* `0.9.0` - Update to wgpu `27.0`, Bevy `0.18.0`. Textures now maintain settings from Bevy `ImageSampler`
 * `0.8.0` - Add `docking` feature. Update to wgpu `26.0`, Bevy `0.17.0`. Fix render glitch when texture format / display scale is changed.
 * `0.7.2` - Fix backend renderer to support ImGui 1.86+ modals
 * `0.7.1` - Fix for crash in imgui-wpu-rs when the draw list is empty

--- a/examples/render-to-texture.rs
+++ b/examples/render-to-texture.rs
@@ -1,7 +1,7 @@
 //! Shows how to render to a texture. Useful for mirrors, UI, or exporting images.
 
 use bevy::{
-    camera::visibility::RenderLayers,
+    camera::{visibility::RenderLayers, RenderTarget},
     prelude::*,
     render::render_resource::{
         Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
@@ -112,17 +112,20 @@ fn setup(
         Camera {
             // render before the "main pass" camera
             order: -1,
-            target: image_handle.clone().into(),
             clear_color: Color::WHITE.into(),
             ..default()
         },
         Camera3d::default(),
+        RenderTarget::Image(image_handle.clone().into()),
         Transform::from_translation(Vec3::new(0.0, 0.0, 15.0)).looking_at(Vec3::ZERO, Vec3::Y),
         first_pass_layer,
     ));
 
     // The main pass camera.
-    commands.spawn(Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y));
+    commands.spawn((
+        Transform::from_xyz(0.0, 0.0, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+        Camera3d::default(),
+    ));
 }
 
 /// Rotates the inner cube (first pass)


### PR DESCRIPTION
Includes a fix for `render-to-texture` example where the main camera was missing a camera component